### PR TITLE
allow streaming responses from get changes

### DIFF
--- a/src/AmazonCloudDriveApi/AmazonCloudDriveApi.Shared/AmazonCloudDriveApi.Shared.projitems
+++ b/src/AmazonCloudDriveApi/AmazonCloudDriveApi.Shared/AmazonCloudDriveApi.Shared.projitems
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Amazon.CloudDrive</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CloudDrive\Changes\CloudChangesStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MimeTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CloudDrive\CloudDriveApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CloudDrive\Nodes\Enums.cs" />
@@ -44,12 +45,10 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Amazon\" />
-    <Folder Include="$(MSBuildThisFileDirectory)CloudDrive\" />
     <Folder Include="$(MSBuildThisFileDirectory)CloudDrive\Nodes\" />
     <Folder Include="$(MSBuildThisFileDirectory)CloudDrive\Nodes\Requests\" />
     <Folder Include="$(MSBuildThisFileDirectory)CloudDrive\Nodes\Models\" />
     <Folder Include="$(MSBuildThisFileDirectory)CloudDrive\Nodes\Filters\" />
     <Folder Include="$(MSBuildThisFileDirectory)CloudDrive\Account\" />
-    <Folder Include="$(MSBuildThisFileDirectory)CloudDrive\Changes\" />
   </ItemGroup>
 </Project>

--- a/src/AmazonCloudDriveApi/AmazonCloudDriveApi.Shared/CloudDrive/Changes/CloudChangesResult.cs
+++ b/src/AmazonCloudDriveApi/AmazonCloudDriveApi.Shared/CloudDrive/Changes/CloudChangesResult.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using SimpleAuth;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Amazon.CloudDrive
 {
@@ -10,9 +12,11 @@ namespace Amazon.CloudDrive
 
 		public string Checkpoint { get; set; }
 
-		public List<CloudNode> Nodes { get; set; }
+		public List<JObject> Nodes { get; set; }
 
 		public int StatusCode { get; set; }
+
+        public bool End { get; set; }
 	}
 }
 

--- a/src/AmazonCloudDriveApi/AmazonCloudDriveApi.Shared/CloudDrive/Changes/CloudChangesStream.cs
+++ b/src/AmazonCloudDriveApi/AmazonCloudDriveApi.Shared/CloudDrive/Changes/CloudChangesStream.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Newtonsoft.Json;
+
+namespace Amazon.CloudDrive
+{
+    public class CloudChangesStream : StreamReader
+    {
+        private const char UnixNewLine = '\n';
+
+        public CloudChangesStream(Stream stream)
+            : base(stream)
+        { }
+
+        public override int Read([In, Out]char[] buffer, int index, int count)
+        {
+            var ret = 0;
+
+            for (var i = index; i < buffer.Length - 1; i++) {
+                var c = Read();
+                if (c == -1) break;
+                if (c == UnixNewLine) break;
+
+                buffer[i] = (char)c;
+                ret++;
+            }
+
+            return ret;
+        }
+
+        public JsonTextReader GetJsonTextReader()
+        {
+            return new JsonTextReader(this);
+        }
+    }
+}


### PR DESCRIPTION
It is not that the response is malformed as your comments indicate, it is because it is designed to be a streaming response that can be read in chunks. The chunks are delimited by a new line. If you have a large account you can set to chunkSize: to 100, and that will give you back about 100 node changes per line. When you receive a `{end:true}` chunk, that indicates there are no more changes coming down the line.  

Not knowing your intended use of this it was hard to determine a good buffer to buffer the changes as they arrived from the service and before they were deserialized.  In my experience the deserialization blocks the receiving of new bytes too long, and the service gives up because it looks like a dead connection from the client.  That is why for this I am buffering them into a `MemoryStream`. Depending on your use case you might want to choose something a little more free flowing.

On the response nodes from get changes, you also want to keep this as a raw `JObject`. The reason for this is if you deserialize it too soon you loose the "changes". Because the "changes" part of get changes, includes only the changed properties of the node.  If you deserialize the object you don't really know what properties were changed.
